### PR TITLE
Fix overloaded titles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :default do
   # DB
   gem 'activerecord', require: 'active_record'
   gem 'activerecord-oracle_enhanced-adapter'
-  #gem 'ruby-oci8'
+  gem 'ruby-oci8'
   gem 'sqlite3'
 
   # Logging

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :default do
   # DB
   gem 'activerecord', require: 'active_record'
   gem 'activerecord-oracle_enhanced-adapter'
-  gem 'ruby-oci8'
+  #gem 'ruby-oci8'
   gem 'sqlite3'
 
   # Logging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,6 @@ GEM
       parser (>= 2.7.1.5)
     rubocop-checkstyle_formatter (0.4.0)
       rubocop (>= 0.35.1)
-    ruby-oci8 (2.2.9)
     ruby-plsql (0.7.1)
     ruby-progressbar (1.11.0)
     ruby_figlet (0.6.1)
@@ -251,7 +250,6 @@ DEPENDENCIES
   rss
   rubocop
   rubocop-checkstyle_formatter
-  ruby-oci8
   ruby_figlet
   soundcloud
   sqlite3
@@ -261,7 +259,7 @@ DEPENDENCIES
   youtube-dl.rb!
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 3.0.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.2.15

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -123,6 +123,7 @@ en:
   polls:
     cross-server: 'That channel is on a different server.'
     too-many-opts: 'Your poll has too many options.'
+    title-too-long: 'The title of your poll is too long.'
 
   queries:
     query:

--- a/modules/polls.rb
+++ b/modules/polls.rb
@@ -75,6 +75,8 @@ module Polls
       embed t('polls.cross-server')
     elsif opts.size > 9
       embed t('polls.too-many-opts')
+    elsif title.length > 256
+      embed t('polls.title-too-long')
     elsif !poll_allowed?(event, channel)
       embed t(:no_perms)
     else


### PR DESCRIPTION
This should fix #36. We actually don't need to account for the poll options being overloaded, as Discord's character limit for embed descriptions is greater than the biggest poll that a user can send. It adds a new message, though, so it needs translations for the other locales (I have already added the English one).