### PR TITLE
Starboard module

### DIFF
--- a/config/global.yml.example
+++ b/config/global.yml.example
@@ -38,6 +38,7 @@ global:
     - queries
     - roles
     - snippets
+    - starboard
     - util
     - xkcd
 
@@ -49,4 +50,9 @@ global:
     - name: hello
       text: Hello, world!
 
-# vim: ft=yaml
+  # default starboard settings for all servers
+  starboard:
+    emoji: "⭐"
+    minimum_reacts: 5
+
+# vim: ft=yaml:ts=2:sw=2:set expandtab

--- a/lib/db/models/starboard_entries.rb
+++ b/lib/db/models/starboard_entries.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# Entry in a server's starboard
+class StarboardEntry < ActiveRecord::Base; end

--- a/lib/db/schema.rb
+++ b/lib/db/schema.rb
@@ -78,7 +78,7 @@ module Database
         t.timestamps
       end
 
-      create_table :starboard_entries do [t]
+      create_table :starboard_entries do |t|
         t.integer :server_id, null: false
         t.integer :message_id, null: false, unique: true
         t.integer :starboard_id, null: false, unique: true

--- a/lib/db/schema.rb
+++ b/lib/db/schema.rb
@@ -82,6 +82,8 @@ module Database
         t.integer :server_id, null: false
         t.integer :message_id, null: false, unique: true
         t.integer :starboard_id, null: false, unique: true
+
+        t.timestamps
       end
 
       add_index :server_configs, :server_id, unique: true

--- a/lib/db/schema.rb
+++ b/lib/db/schema.rb
@@ -78,6 +78,12 @@ module Database
         t.timestamps
       end
 
+      create_table :starboard_entries do [t]
+        t.integer :server_id, null: false
+        t.integer :message_id, null: false, unique: true
+        t.integer :starboard_id, null: false, unique: true
+      end
+
       add_index :server_configs, :server_id, unique: true
       add_index :user_configs, :user_id, unique: true
       add_index :queries, :server_id

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -285,6 +285,27 @@ en:
 
         success: 'Property `%s` of snippet `%s` is now `%s`.'
 
+    starboard:
+      help:
+        emoji: 'set the starboard reaction'
+        minimum-reacts: 'set the amount of reactions required for starboard'
+        channel: 'set the starboard channel'
+        delete-msgs: '(bool) will starboard messages be removed with the original?'
+
+      emoji:
+        show-opt: 'The starboard emoji is `%s`.'
+        none-provided: 'Please provide a valid emoji'
+
+      minimum-reacts:
+        show-opt: 'The minimum number of reactions to appear on the starboard is `%s`.'
+        too-low: 'Please provide a number greater than 0.'
+
+      delete:
+        enabled: 'Starboard messages will be removed when the original is deleted.'
+        disabled: 'Starboard messages will not be removed when the original is deleted.'
+
+      success: 'The indicated value is now set to `%s`.'
+
     rolegroup:
 
     reaction:
@@ -314,3 +335,5 @@ en:
     misc:
 
     nyi: 'Not yet implemented.'
+
+# vim: ft=yaml:ts=2:sw=2:set expandtab

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -295,7 +295,7 @@ en:
       emoji:
         show-opt: 'The starboard emoji is `%s`.'
         none-provided: 'Please provide a valid emoji.'
-				cross-server: 'Please do not use cross-server emojis.'
+        cross-server: 'Please do not use cross-server emojis.'
 
       minimum-reacts:
         show-opt: 'The minimum number of reactions to appear on the starboard is `%s`.'

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -214,6 +214,7 @@ en:
       reaction: 'configure reaction actions'
       blacklist: 'manage blacklist entries'
       misc: 'setup miscellaneous options'
+      starboard: 'configure the starboard'
 
     log-channel:
       help:

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -304,6 +304,10 @@ en:
         enabled: 'Starboard messages will be removed when the original is deleted.'
         disabled: 'Starboard messages will not be removed when the original is deleted.'
 
+      channel:
+        show-opt: 'The starboard channel is %s.'
+        success: 'The starboard channel is now %s.'
+
       success: 'The indicated value is now set to `%s`.'
 
     rolegroup:

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -288,8 +288,8 @@ en:
 
     starboard:
       help:
-        emoji: 'set the starboard reaction'
-        minimum-reacts: 'set the amount of reactions required for starboard'
+        emoji: 'set the starboard reaction emoji'
+        minimum-reacts: 'set the number of reactions required to star a message'
         channel: 'set the starboard channel'
         delete-msgs: '(bool) will starboard messages be removed with the original?'
 

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -294,7 +294,8 @@ en:
 
       emoji:
         show-opt: 'The starboard emoji is `%s`.'
-        none-provided: 'Please provide a valid emoji'
+        none-provided: 'Please provide a valid emoji.'
+				cross-server: 'Please do not use cross-server emojis.'
 
       minimum-reacts:
         show-opt: 'The minimum number of reactions to appear on the starboard is `%s`.'

--- a/modules/admin/config.rb
+++ b/modules/admin/config.rb
@@ -297,7 +297,6 @@ module Admin
         cfg.options['starboard-delete'] = opt
         embed t('cfg.starboard.delete.success', opt)
       end
-    end
 
     when 'misc', 'm'
       subcmd = args.shift

--- a/modules/admin/config.rb
+++ b/modules/admin/config.rb
@@ -275,6 +275,10 @@ module Admin
           break
         end
         if event.message.emoji.first
+          unless event.message.emoji.first.server.id == event.server.id
+            embed t('cfg.starboard.emoji.cross-server')
+            break
+          end
           cfg.options['starboard-emoji'] = event.message.emoji.first.name
         elsif event.message.emoji?
           cfg.options['starboard-emoji'] = opt

--- a/modules/admin/config.rb
+++ b/modules/admin/config.rb
@@ -284,7 +284,7 @@ module Admin
           cfg.options['starboard-emoji'] = opt
         end
         cfg.save!
-        embed t('cfg.starboard.emoji.success', opt)
+        embed t('cfg.starboard.success', opt)
       when 'minimum-reacts', 'min', 'm'
         opt = args.shift
         if opt == "show" || opt == "s"
@@ -297,7 +297,7 @@ module Admin
         end
         cfg.options['starboard-minimum'] = opt.to_i
         cfg.save!
-        embed t('cfg.starboard.minimum-reacts.success', opt)
+        embed t('cfg.starboard.success', opt)
       when 'channel', 'c'
         opt = args.shift
         if opt == "show" || opt == "s"
@@ -311,16 +311,20 @@ module Admin
         channel = event.bot.channel(opt)
         cfg.options['starboard-channel'] = channel.id
         cfg.save!
-        embed t('cfg.starboard.channel.success', channel.mention)
+        embed t('cfg.starboard.success', channel.mention)
       when 'delete-messages', 'delete', 'd'
         opt = ActiveModel::Type::Boolean.new.cast(args.shift)
         if opt == "show" || opt == "s"
-          embed t('cfg.starboard.delete.show-opt', cfg.options['starboard-delete'] ? "true" : "false")
+          if cfg.options['starboard-delete']
+            embed t('cfg.starboard.delete.enabled')
+          else
+            embed t('cfg.starboard.delete.disabled')
+          end
           break
         end
         cfg.options['starboard-delete'] = opt
         cfg.save!
-        embed t('cfg.starboard.delete.success', opt)
+        embed t('cfg.starboard.success', opt)
       end
 
     when 'misc', 'm'

--- a/modules/admin/config.rb
+++ b/modules/admin/config.rb
@@ -275,6 +275,7 @@ module Admin
         end
         opt = event.message.emoji.first.name
         cfg.options['starboard-emoji'] = opt
+        cfg.save!
         embed t('cfg.starboard.emoji.success', opt)
       when 'minimum-reacts', 'min', 'm'
         opt = args.shift.first.to_i
@@ -283,6 +284,7 @@ module Admin
           break
         end
         cfg.options['starboard-minimum'] = opt
+        cfg.save!
         embed t('cfg.starboard.minimum-reacts.success', opt)
       when 'channel', 'c'
         opt = event.bot.channel(args.shift)
@@ -291,10 +293,12 @@ module Admin
           break
         end
         cfg.options['starboard-channel'] = opt.id
+        cfg.save!
         embed t('cfg.starboard.channel.success', opt.mention)
       when 'delete-messages', 'delete', 'd'
         opt = ActiveModel::Type::Boolean.new.cast(args.shift)
         cfg.options['starboard-delete'] = opt
+        cfg.save!
         embed t('cfg.starboard.delete.success', opt)
       end
 

--- a/modules/admin/config.rb
+++ b/modules/admin/config.rb
@@ -26,6 +26,7 @@ module Admin
       Config.help_msg event, 'cfg', %i[
         help log-channel modules prefix colors
         snippet rolegroup reaction blacklist misc
+		starboard
       ]
 
     when 'log-channel', 'lc'
@@ -262,6 +263,42 @@ module Admin
 
       end
 
+    when 'starboard', 'sb'
+      subcmd = args.shift
+      case subcmd
+      when 'help', 'h', nil
+        Config.help_msg event, 'cfg starboard', %i[emoji minimum-reacts channel delete-msgs]
+      when 'emoji', 'e'
+        unless event.message.emoji?
+          embed t('cfg.starboard.emoji.none-provided')
+          break
+        end
+        opt = event.message.emoji.first.name
+        cfg.options['starboard-emoji'] = opt
+        embed t('cfg.starboard.emoji.success', opt)
+      when 'minimum-reacts', 'min', 'm'
+        opt = args.shift.first.to_i
+        unless opt > 0
+          embed t('cfg.starboard.minimum-reacts.too-low')
+          break
+        end
+        cfg.options['starboard-minimum'] = opt
+        embed t('cfg.starboard.minimum-reacts.success', opt)
+      when 'channel', 'c'
+        opt = event.bot.channel(args.shift)
+        unless opt
+          embed t('cfg.starboard.channel.invalid-channel')
+          break
+        end
+        cfg.options['starboard-channel'] = opt.id
+        embed t('cfg.starboard.channel.success', opt.mention)
+      when 'delete-messages', 'delete', 'd'
+        opt = ActiveModel::Type::Boolean.new.cast(args.shift)
+        cfg.options['starboard-delete'] = opt
+        embed t('cfg.starboard.delete.success', opt)
+      end
+    end
+
     when 'misc', 'm'
       subcmd = args.shift
       cfg.options ||= {}
@@ -279,3 +316,4 @@ module Admin
   # rubocop: enable Metrics/BlockLength
 end
 # rubocop: enable Metrics/ModuleLength, Metrics/BlockNesting
+# vim: ts=2:sw=2:set expandtab

--- a/modules/admin/config.rb
+++ b/modules/admin/config.rb
@@ -26,7 +26,7 @@ module Admin
       Config.help_msg event, 'cfg', %i[
         help log-channel modules prefix colors
         snippet rolegroup reaction blacklist misc
-		starboard
+        starboard
       ]
 
     when 'log-channel', 'lc'
@@ -270,7 +270,7 @@ module Admin
         Config.help_msg event, 'cfg starboard', %i[emoji minimum-reacts channel delete-msgs]
       when 'emoji', 'e'
         opt = args.shift
-        if opt == "show" || opt == "s"
+        if %w[show s].include?(opt)
           embed t('cfg.starboard.emoji.show-opt', cfg.options['starboard-emoji'])
           break
         end
@@ -290,11 +290,11 @@ module Admin
         embed t('cfg.starboard.success', opt)
       when 'minimum-reacts', 'min', 'm'
         opt = args.shift
-        if opt == "show" || opt == "s"
+        if %w[show s].include?(opt)
           embed t('cfg.starboard.minimum-reacts.show-opt', cfg.options['starboard-minimum'])
           break
         end
-        unless opt.to_i > 0
+        unless opt.to_i.positive?
           embed t('cfg.starboard.minimum-reacts.too-low')
           break
         end
@@ -303,7 +303,7 @@ module Admin
         embed t('cfg.starboard.success', opt)
       when 'channel', 'c'
         opt = args.shift
-        if opt == "show" || opt == "s"
+        if %w[show s].include?(opt)
           embed t('cfg.starboard.channel.show-opt', format('<#%s>', cfg.options['starboard-channel']))
           break
         end
@@ -317,7 +317,7 @@ module Admin
         embed t('cfg.starboard.channel.success', channel.mention)
       when 'delete-messages', 'delete', 'd'
         opt = ActiveModel::Type::Boolean.new.cast(args.shift)
-        if opt == "show" || opt == "s"
+        if %w[show s].include?(opt)
           if cfg.options['starboard-delete']
             embed t('cfg.starboard.delete.enabled')
           else

--- a/modules/admin/config.rb
+++ b/modules/admin/config.rb
@@ -308,9 +308,10 @@ module Admin
           embed t('cfg.starboard.channel.invalid-channel')
           break
         end
-        cfg.options['starboard-channel'] = event.bot.channel(opt).id
+        channel = event.bot.channel(opt)
+        cfg.options['starboard-channel'] = channel.id
         cfg.save!
-        embed t('cfg.starboard.channel.success', opt.mention)
+        embed t('cfg.starboard.channel.success', channel.mention)
       when 'delete-messages', 'delete', 'd'
         opt = ActiveModel::Type::Boolean.new.cast(args.shift)
         if opt == "show" || opt == "s"

--- a/modules/admin/config.rb
+++ b/modules/admin/config.rb
@@ -269,34 +269,54 @@ module Admin
       when 'help', 'h', nil
         Config.help_msg event, 'cfg starboard', %i[emoji minimum-reacts channel delete-msgs]
       when 'emoji', 'e'
+        opt = args.shift
+        if opt.in? ["show", "s"]
+          embed t('cfg.starboard.emoji.show-opt', cfg.options['starboard-emoji'])
+          break
+        end
         unless event.message.emoji?
           embed t('cfg.starboard.emoji.none-provided')
           break
         end
-        opt = event.message.emoji.first.name
-        cfg.options['starboard-emoji'] = opt
+        if event.message.emoji.first
+          cfg.options['starboard-emoji'] = event.message.emoji.first.name
+        else
+          cfg.options['starboard-emoji'] = opt
+        end
         cfg.save!
         embed t('cfg.starboard.emoji.success', opt)
       when 'minimum-reacts', 'min', 'm'
-        opt = args.shift.first.to_i
-        unless opt > 0
+        opt = args.shift
+        if opt.in? ["show", "s"]
+          embed t('cfg.starboard.minimum-reacts.show-opt', cfg.options['starboard-minimum'])
+          break
+        end
+        unless opt.to_i > 0
           embed t('cfg.starboard.minimum-reacts.too-low')
           break
         end
-        cfg.options['starboard-minimum'] = opt
+        cfg.options['starboard-minimum'] = opt.to_i
         cfg.save!
         embed t('cfg.starboard.minimum-reacts.success', opt)
       when 'channel', 'c'
-        opt = event.bot.channel(args.shift)
+        opt = args.shift
+        if opt.in? ["show", "s"]
+          embed t('cfg.starboard.channel.show-opt', format('<#%s>', cfg.options['starboard-channel']))
+          break
+        end
         unless opt
           embed t('cfg.starboard.channel.invalid-channel')
           break
         end
-        cfg.options['starboard-channel'] = opt.id
+        cfg.options['starboard-channel'] = event.bot.channel(opt).id
         cfg.save!
         embed t('cfg.starboard.channel.success', opt.mention)
       when 'delete-messages', 'delete', 'd'
         opt = ActiveModel::Type::Boolean.new.cast(args.shift)
+        if opt.in? ["show", "s"]
+          embed t('cfg.starboard.delete.show-opt', cfg.options['starboard-delete'] ? "true" : "false")
+          break
+        end
         cfg.options['starboard-delete'] = opt
         cfg.save!
         embed t('cfg.starboard.delete.success', opt)

--- a/modules/admin/config.rb
+++ b/modules/admin/config.rb
@@ -270,7 +270,7 @@ module Admin
         Config.help_msg event, 'cfg starboard', %i[emoji minimum-reacts channel delete-msgs]
       when 'emoji', 'e'
         opt = args.shift
-        if opt.in? ["show", "s"]
+        if opt == "show" || opt == "s"
           embed t('cfg.starboard.emoji.show-opt', cfg.options['starboard-emoji'])
           break
         end
@@ -287,7 +287,7 @@ module Admin
         embed t('cfg.starboard.emoji.success', opt)
       when 'minimum-reacts', 'min', 'm'
         opt = args.shift
-        if opt.in? ["show", "s"]
+        if opt == "show" || opt == "s"
           embed t('cfg.starboard.minimum-reacts.show-opt', cfg.options['starboard-minimum'])
           break
         end
@@ -300,7 +300,7 @@ module Admin
         embed t('cfg.starboard.minimum-reacts.success', opt)
       when 'channel', 'c'
         opt = args.shift
-        if opt.in? ["show", "s"]
+        if opt == "show" || opt == "s"
           embed t('cfg.starboard.channel.show-opt', format('<#%s>', cfg.options['starboard-channel']))
           break
         end
@@ -313,7 +313,7 @@ module Admin
         embed t('cfg.starboard.channel.success', opt.mention)
       when 'delete-messages', 'delete', 'd'
         opt = ActiveModel::Type::Boolean.new.cast(args.shift)
-        if opt.in? ["show", "s"]
+        if opt == "show" || opt == "s"
           embed t('cfg.starboard.delete.show-opt', cfg.options['starboard-delete'] ? "true" : "false")
           break
         end

--- a/modules/admin/config.rb
+++ b/modules/admin/config.rb
@@ -274,14 +274,13 @@ module Admin
           embed t('cfg.starboard.emoji.show-opt', cfg.options['starboard-emoji'])
           break
         end
-        unless event.message.emoji?
-          embed t('cfg.starboard.emoji.none-provided')
-          break
-        end
         if event.message.emoji.first
           cfg.options['starboard-emoji'] = event.message.emoji.first.name
-        else
+        elsif event.message.emoji?
           cfg.options['starboard-emoji'] = opt
+        else
+          embed t('cfg.starboard.emoji.none-provided')
+          break
         end
         cfg.save!
         embed t('cfg.starboard.success', opt)
@@ -311,7 +310,7 @@ module Admin
         channel = event.bot.channel(opt)
         cfg.options['starboard-channel'] = channel.id
         cfg.save!
-        embed t('cfg.starboard.success', channel.mention)
+        embed t('cfg.starboard.channel.success', channel.mention)
       when 'delete-messages', 'delete', 'd'
         opt = ActiveModel::Type::Boolean.new.cast(args.shift)
         if opt == "show" || opt == "s"

--- a/modules/starboard.rb
+++ b/modules/starboard.rb
@@ -2,101 +2,101 @@
 
 # Starboard commands
 module Starboard
-	extend Discordrb::Commands::CommandContainer
+  extend Discordrb::Commands::CommandContainer
 end
 
 # Reaction event handler
 QBot.bot.reaction_add do |event|
-	scfg = ServerConfig[event.server.id]
-	if scfg.modules_conf['disabled'].include? 'starboard'
-		break
-	end
+  scfg = ServerConfig[event.server.id]
+  if scfg.modules_conf['disabled'].include? 'starboard'
+    break
+  end
 
-	# Define functions for embed
-	## Get author
-	def embed_author(user)
-		{
-			icon_url: user.avatar_url,
-			name: user.username
-		}
-	end
-	## Get message attachment
-	def embed_image(message)
-		if message.attachments.first
-			image = {
-				url: message.attachments.first.url
-			}
-		else
-			image = nil
-		end
-		image
-	end
-	## Get field text
-	def embed_fields(event)
-		[{
-			name: "Message",
-			value: format("[#%s](%s)", event.channel.name, event.message.link)
-		}]
-	end
+  # Define functions for embed
+  ## Get author
+  def embed_author(user)
+    {
+      icon_url: user.avatar_url,
+      name: user.username
+    }
+  end
+  ## Get message attachment
+  def embed_image(message)
+    if message.attachments.first
+      image = {
+        url: message.attachments.first.url
+      }
+    else
+      image = nil
+    end
+    image
+  end
+  ## Get field text
+  def embed_fields(event)
+    [{
+      name: "Message",
+      value: format("[#%s](%s)", event.channel.name, event.message.link)
+    }]
+  end
 
-	# Get variables from db
-	emoji_name = (scfg.options['starboard-emoji'] || QBot.config.global.starboard.emoji)
-	min = (scfg.options['starboard-minimum'] || QBot.config.global.starboard.minimum_reacts)
-	starboard = scfg.options['starboard-channel']
-	sb_entry = StarboardEntry.where(message_id: event.message.id).first
-	# Handle reactions
-	if (starboard) \
-			&& (event.emoji.name == emoji_name) \
-			&& !(sb_entry) \
-			&& (event.channel.id != starboard)
-		# Get channel from cache
-		starboard_channel = event.bot.channel(starboard)
-		# Count reactions
-		rcount = event.message.reacted_with(event.emoji, limit: min).length
-		if rcount >= min
-			# Send starboard embed
-			## Create embed
-			embed_msg = embed(target: starboard_channel) do |m|
-				m.author = embed_author(event.message.author)
-				m.description = event.message.content
-				#m.fields = embed_fields(event)
-				m.image = embed_image(event.message)
-				m.footer = {text: event.message.id}
-				m.timestamp = event.message.creation_time
-			end
-			## Send embed
-			starboard_msg = embed_msg
-			# Add entry to database
-			StarboardEntry.create(message_id: event.message.id,
-									starboard_id: starboard_msg.id,
-									server_id: event.server.id)
-		end
-	end
+  # Get variables from db
+  emoji_name = (scfg.options['starboard-emoji'] || QBot.config.global.starboard.emoji)
+  min = (scfg.options['starboard-minimum'] || QBot.config.global.starboard.minimum_reacts)
+  starboard = scfg.options['starboard-channel']
+  sb_entry = StarboardEntry.where(message_id: event.message.id).first
+  # Handle reactions
+  if (starboard) \
+      && (event.emoji.name == emoji_name) \
+      && !(sb_entry) \
+      && (event.channel.id != starboard)
+    # Get channel from cache
+    starboard_channel = event.bot.channel(starboard)
+    # Count reactions
+    rcount = event.message.reacted_with(event.emoji, limit: min).length
+    if rcount >= min
+      # Send starboard embed
+      ## Create embed
+      embed_msg = embed(target: starboard_channel) do |m|
+        m.author = embed_author(event.message.author)
+        m.description = event.message.content
+        #m.fields = embed_fields(event)
+        m.image = embed_image(event.message)
+        m.footer = {text: event.message.id}
+        m.timestamp = event.message.creation_time
+      end
+      ## Send embed
+      starboard_msg = embed_msg
+      # Add entry to database
+      StarboardEntry.create(message_id: event.message.id,
+                            starboard_id: starboard_msg.id,
+                            server_id: event.server.id)
+    end
+  end
 end
 
 # Deletion event handler
 QBot.bot.message_delete do |event|
-	scfg = ServerConfig[event.channel.server.id]
-	if scfg.modules_conf['disabled'].include? 'starboard'
-		break
-	end
+  scfg = ServerConfig[event.channel.server.id]
+  if scfg.modules_conf['disabled'].include? 'starboard'
+    break
+  end
 
-	# Get values from db
-	delete_msgs = scfg.options['starboard-delete']
-	starboard = scfg.options['starboard-channel']
-	starboard_channel = event.bot.channel(starboard)
-	sb_entries = StarboardEntry.where(starboard_id: event.id)
-	sb_entry = StarboardEntry.where(message_id: event.id).first
+  # Get values from db
+  delete_msgs = scfg.options['starboard-delete']
+  starboard = scfg.options['starboard-channel']
+  starboard_channel = event.bot.channel(starboard)
+  sb_entries = StarboardEntry.where(starboard_id: event.id)
+  sb_entry = StarboardEntry.where(message_id: event.id).first
 
-	# Handle deletions
-	## Handle starboard message deletion
-	if event.channel.id == starboard
-		# Delete message from records
-		sb_entries.destroy_all
-	## Handle original message deletion
-	else delete_msgs && sb_entry
-		# Delete message
-		starboard_channel.load_message(sb_entry.starboard_id).delete
-	end
+  # Handle deletions
+  ## Handle starboard message deletion
+  if event.channel.id == starboard
+    # Delete message from records
+    sb_entries.destroy_all
+  ## Handle original message deletion
+  else delete_msgs && sb_entry
+    # Delete message
+    starboard_channel.load_message(sb_entry.starboard_id).delete
+  end
 end
-
+# vim: ts=2:sw=2:set expandtab

--- a/modules/starboard.rb
+++ b/modules/starboard.rb
@@ -51,8 +51,8 @@ QBot.bot.reaction_add do |event|
       && (event.channel.id != starboard)
     # Get channel from cache
     starboard_channel = event.bot.channel(starboard)
-    # Count reactions
-    rcount = event.message.reacted_with(event.emoji, limit: min).length
+    # Count reactions and reject the author of the message from the count
+    rcount = event.message.reacted_with(event.emoji, limit: min + 1).reject{ |user| user.id == event.message.author.id }.length
     if rcount >= min
       # Send starboard embed
       ## Create embed

--- a/modules/starboard.rb
+++ b/modules/starboard.rb
@@ -43,13 +43,14 @@ QBot.bot.reaction_add do |event|
 	emoji_name = (scfg.options['starboard-emoji'] || QBot.config.global.starboard.emoji)
 	min = (scfg.options['starboard-minimum'] || QBot.config.global.starboard.minimum)
 	starboard = scfg.options['starboard-channel']
-	starboard_channel = event.bot.channel(starboard)
 	sb_entry = StarboardEntry.where(message_id: event.message.id).first
 	# Handle reactions
 	if (starboard) \
 			&& (event.emoji.name == emoji_name) \
 			&& !(sb_entry) \
 			&& (event.channel.id != starboard)
+		# Get channel from cache
+		starboard_channel = event.bot.channel(starboard)
 		# Count reactions
 		rcount = event.message.reacted_with(event.emoji, limit: min).length
 		if rcount >= min

--- a/modules/starboard.rb
+++ b/modules/starboard.rb
@@ -21,6 +21,7 @@ QBot.bot.reaction_add do |event|
 
   ## Get message attachment
   def embed_image(message)
+    return unless message.attachments.first
     {
       url: message.attachments.first.url
     }

--- a/modules/starboard.rb
+++ b/modules/starboard.rb
@@ -40,12 +40,11 @@ QBot.bot.reaction_add do |event|
 	end
 
 	# Get variables from db
-	## TODO: Settings support
-	emoji_name = (nil ? nil : QBot.config.global.starboard.emoji)
-	min = (nil ? nil : QBot.config.global.starboard.minimum)
-	starboard = 835525656611389450
+	emoji_name = (scfg.options['starboard-emoji'] || QBot.config.global.starboard.emoji)
+	min = (scfg.options['starboard-minimum'] || QBot.config.global.starboard.minimum)
+	starboard = scfg.options['starboard-channel']
 	starboard_channel = event.bot.channel(starboard)
-	sb_entry = StarboardEntry.where(message_id: event.message.id)
+	sb_entry = StarboardEntry.where(message_id: event.message.id).first
 	# Handle reactions
 	if (starboard) \
 			&& (event.emoji.name == emoji_name) \
@@ -81,22 +80,21 @@ QBot.bot.message_delete do |event|
 		break
 	end
 
-	# Get settings from db
-	## TODO: Replace nil with setting values
-	delete_msgs = (nil ? nil : false)
-	starboard = 835509994828464129
+	# Get values from db
+	delete_msgs = scfg.options['starboard-delete']
+	starboard = scfg.options['starboard-channel']
 	starboard_channel = event.bot.channel(starboard)
+	sb_entries = StarboardEntry.where(starboard_id: event.id)
+	sb_entry = StarboardEntry.where(message_id: event.id).first
 
 	# Handle deletions
 	## Handle starboard message deletion
 	if event.channel.id == starboard
 		# Delete message from records
-		sb_entries = StarboardEntry.where(starboard_id: event.id)
 		sb_entries.destroy_all
 	## Handle original message deletion
-	else delete_msgs
+	else delete_msgs && sb_entry
 		# Delete message
-		sb_entry = StarboardEntry.where(message_id: event.id).first
 		starboard_channel.load_message(sb_entry.starboard_id).delete
 	end
 end

--- a/modules/starboard.rb
+++ b/modules/starboard.rb
@@ -41,7 +41,7 @@ QBot.bot.reaction_add do |event|
 
 	# Get variables from db
 	emoji_name = (scfg.options['starboard-emoji'] || QBot.config.global.starboard.emoji)
-	min = (scfg.options['starboard-minimum'] || QBot.config.global.starboard.minimum)
+	min = (scfg.options['starboard-minimum'] || QBot.config.global.starboard.minimum_reacts)
 	starboard = scfg.options['starboard-channel']
 	sb_entry = StarboardEntry.where(message_id: event.message.id).first
 	# Handle reactions

--- a/modules/starboard.rb
+++ b/modules/starboard.rb
@@ -31,6 +31,18 @@ def embed_fields(event)
   }]
 end
 
+## Send starboard embed
+def send_embed(event, channel)
+  # Send starboard embed
+  embed(target: channel) do |m|
+    m.author = embed_author(event.message.author)
+    m.description = event.message.content
+    # m.fields = embed_fields(event)
+    m.image = embed_image(event.message)
+    m.timestamp = event.message.creation_time
+  end
+end
+
 # Get variables
 def fetch_values(config, event)
   [
@@ -50,7 +62,10 @@ QBot.bot.reaction_add do |event|
   min = (scfg.options['starboard-minimum'] || QBot.config.global.starboard.minimum_reacts)
 
   # Handle reactions
-  if starboard && !sb_entry && (event.emoji.name == emoji_name) && (event.channel.id != starboard)
+  if starboard \
+      && !sb_entry \
+      && (event.emoji.name == emoji_name) \
+      && (event.channel.id != starboard)
     # Get channel from cache
     starboard_channel = event.bot.channel(starboard)
     # Count reactions and reject the author of the message from the count
@@ -59,20 +74,11 @@ QBot.bot.reaction_add do |event|
     end.length
 
     if rcount >= min
-      # Send starboard embed
-      ## Create embed
-      embed_msg = embed(target: starboard_channel) do |m|
-        m.author = embed_author(event.message.author)
-        m.description = event.message.content
-        # m.fields = embed_fields(event)
-        m.image = embed_image(event.message)
-        m.footer = { text: event.message.id }
-        m.timestamp = event.message.creation_time
-      end
-      ## Send embed
-      starboard_msg = embed_msg
+      starboard_msg = send_embed(event, starboard_channel)
       # Add entry to database
-      StarboardEntry.create(message_id: event.message.id, starboard_id: starboard_msg.id, server_id: event.server.id)
+      StarboardEntry.create(message_id: event.message.id,
+                            starboard_id: starboard_msg.id,
+                            server_id: event.server.id)
     end
   end
 end

--- a/modules/starboard.rb
+++ b/modules/starboard.rb
@@ -22,6 +22,7 @@ QBot.bot.reaction_add do |event|
   ## Get message attachment
   def embed_image(message)
     return unless message.attachments.first
+
     {
       url: message.attachments.first.url
     }

--- a/modules/starboard.rb
+++ b/modules/starboard.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+# Starboard commands
+module Starboard
+	extend Discordrb::Commands::CommandContainer
+end
+
+# Reaction event handler
+QBot.bot.reaction_add do |event|
+	scfg = ServerConfig[event.server.id]
+	if scfg.modules_conf['disabled'].include? 'starboard'
+		break
+	end
+
+	# Define functions for embed
+	## Get author
+	def embed_author(user)
+		{
+			icon_url: user.avatar_url,
+			name: user.username
+		}
+	end
+	## Get message attachment
+	def embed_image(message)
+		if message.attachments.first
+			image = {
+				url: message.attachments.first.url
+			}
+		else
+			image = nil
+		end
+		image
+	end
+	## Get field text
+	def embed_fields(event)
+		[{
+			name: "Message",
+			value: format("[#%s](%s)", event.channel.name, event.message.link)
+		}]
+	end
+
+	# Get variables from db
+	## TODO: Settings support
+	emoji_name = (nil ? nil : QBot.config.global.starboard.emoji)
+	min = (nil ? nil : QBot.config.global.starboard.minimum)
+	starboard = event.bot.channel("835525656611389450")
+	sbmsg = StarboardEntry.where(message_id: event.message.id)
+	# Handle reactions
+	## TODO: See if db has message
+	if (starboard) \
+			&& (event.emoji.name == emoji_name) \
+			&& !(sbmsg) \
+			&& (event.message.channel != starboard)
+		# Count reactions
+		rcount = event.message.reacted_with(event.emoji, limit: min).length
+		if rcount >= min
+			# Send starboard embed
+			## Create embed
+			embed_msg = embed(target: starboard) do |m|
+				m.author = embed_author(event.message.author)
+				m.description = event.message.content
+				m.image = embed_image(event.message)
+				m.footer = {text: event.message.id}
+				m.timestamp = event.message.creation_time
+			end
+			## Send embed
+			embed_msg
+		end
+	end
+end
+
+# Deletion event handler
+QBot.bot.message_delete do |event|
+	scfg = ServerConfig[event.channel.server.id]
+	if scfg.modules_conf['disabled'].include? 'starboard'
+		break
+	end
+
+	# Get settings from db
+	## TODO: Replace nil with setting values
+	delete_msgs = (nil ? nil : false)
+	starboard = event.bot.channel("835509994828464129")
+
+	## TODO: Delete entries from db if starboard msg was deleted
+	# Handle deletions
+	## Handle starboard message deletion
+	if event.channel.id == starboard.id
+		# Delete message from records
+		## TODO: Get message using footer_text& to delete activerecord entry
+		sbmsg = StarboardEntry.where(starboard_id: event.id)
+		sbmsg.destroy
+	end
+	## Handle original message deletion
+	if delete_msgs ### TODO: Get setting of delete or not
+		# Delete message
+		sbmsg = StarboardEntry.where(message_id: event.id)
+		# TODO: Set up the database models to delete the message
+		event.bot.channel("835509994828464129").load_message(sbmsg.starboard_id).delete
+		sbmsg.destroy
+	end
+end
+

--- a/modules/starboard.rb
+++ b/modules/starboard.rb
@@ -32,7 +32,7 @@ QBot.bot.reaction_add do |event|
   def embed_fields(event)
     [{
       name: 'Message',
-      value: format('[#%s](%s)', event.channel.name, event.message.link)
+      value: format('[#%<name>s](%<link>s)', name: event.channel.name, link: event.message.link)
     }]
   end
 


### PR DESCRIPTION
`en_kawaii` translations coming soon.

Ran through rubocop (with default settings), the only offense is:
```
modules/starboard.rb:9:1: C: Metrics/BlockLength: Block has too many lines. [46/25]
QBot.bot.reaction_add do |event| ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

There is not much I can do about it however, since it is where the core functionality of the module resides.