### PR TITLE
Nickname automoderation

### DIFF
--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -314,3 +314,7 @@ en:
     misc:
 
     nyi: 'Not yet implemented.'
+
+  nicknames:
+    missing-permissions: "I was unable to change `%s`'s nickname due to missing permissions."
+    moderated: "Your nickname has been moderated. Please do not add an exclamation point in front of your name to raise yourself to the top of the user list."

--- a/modules/nicknames.rb
+++ b/modules/nicknames.rb
@@ -1,0 +1,47 @@
+# frozen-string-literal: true
+
+# Remove !'s from nicknames
+module Nicknames
+  extend Discordrb::Commands::CommandContainer
+end
+
+QBot.bot.member_update do |event|
+  sc = ServerConfig[event.server.id]
+  break if sc.modules_conf['disabled'].include? 'nicknames'
+
+  if event.user.nick[0] == '!'
+    begin
+      event.user.set_nick("#{event.user.nick.match(/^!*(.*)$/)[1]}z")
+    rescue Discordrb::Errors::NoPermission
+      # Alert the owner about not being able to change the nickname due to missing permissions
+      suppress(Discordrb::Errors::NoPermission) do
+        # And hope that they don't have the bot blocked or dms off
+        event.server.owner.pm t('nicknames.missing-permissions', event.user.username)
+      end
+    else
+      suppress(Discordrb::Errors::NoPermission) do
+        event.user.pm t('nicknames.moderated')
+      end
+    end
+  end
+end
+
+QBot.bot.member_join do |event|
+  sc = ServerConfig[event.server.id]
+  break if sc.modules_conf['disabled'].include? 'nicknames'
+
+  if event.user.username[0] == '!'
+    begin
+      event.user.set_nick("#{event.user.username.match(/^!*(.*)$/)[1]}z")
+      event.user.pm t('nicknames.moderated')
+    rescue Discordrb::Errors::NoPermission
+      suppress(Discordrb::Errors::NoPermission) do
+        event.server.owner.pm t('nicknames.missing-permissions', event.user.username)
+      end
+    else
+      suppress(Discordrb::Errors::NoPermission) do
+        event.user.pm t('nicknames.moderated')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Aims to add automoderation for usernames and nicknames by automatically removing `!`'s. Linted through rubocop, no offenses.

Since this is pretty aggressive, an implementation for `cfg modules` should probably be made before merging/deploying.