### PR TITLE
feat: color previews for listcolors

### DIFF
--- a/modules/colors.rb
+++ b/modules/colors.rb
@@ -124,12 +124,12 @@ module Colors # rubocop: disable Metrics/ModuleLength, Style/CommentedKeyword
     list = colors.sort_by(&:idx).map do |c|
       idx = c.idx.to_s.rjust(2)
       r = c.role
-      "#{idx}: ##{r.color.hex.rjust(6, '0')} #{r.name}"
+      "`#{idx}:` `##{r.color.hex.rjust(6, '0')}` <@&#{r.id}>"
     end
 
     embed do |m|
       m.title = t 'colors.list.title'
-      m.description = "```#{list.join "\n"}```"
+      m.description = list.join "\n"
     end
   end
 


### PR DESCRIPTION
Should look something like this
![](https://cdn.discordapp.com/attachments/821433636061577246/1012873607963226172/unknown.png)
Can't figure out why the roles are listed in reverse order