### PR TITLE
Add config-provided allowlist for ignore_bots instead of flat boolean on bot construction

### DIFF
--- a/config/global.yml.example
+++ b/config/global.yml.example
@@ -50,4 +50,7 @@ modules:
 
 default_prefix: '.'
 
+bot_id_allowlist:
+  - 204255221017214977
+
 # vim: ft=yaml

--- a/lib/init.rb
+++ b/lib/init.rb
@@ -29,7 +29,7 @@ module QBot
       name: 'QueryBot',
       prefix: method(:cmd_prefix),
       fancy_log: true,
-      ignore_bots: true,
+      ignore_bots: false,
       no_permission_message: 'You are not allowed to do that',
       help_command: false,
       intents: Discordrb::INTENTS.keys - %i[

--- a/lib/patches.rb
+++ b/lib/patches.rb
@@ -114,15 +114,19 @@ end
 
 # reimplementing discordrb's ignore_bot with a whitelist
 module CommandEventIntercept
-  def call(event, arguments, _chained = false, _check_permissions = true)
+  # rubocop: disable Style/OptionalBooleanParameter
+  def call(event, arguments, chained = false, check_permissions = true)
+    # rubocop:enable Style/OptionalBooleanParameter
     return if event.author.bot_account && !(QBot.config.bot_id_allowlist.include? event.author.id)
 
-    super(event, arguments, _chained, _check_permissions)
+    super(event, arguments, chained, check_permissions)
   end
 end
 
-module Discordrb::Commands
-  class Command
-    prepend CommandEventIntercept
+module Discordrb
+  module Commands
+    class Command
+      prepend CommandEventIntercept
+    end
   end
 end

--- a/lib/patches.rb
+++ b/lib/patches.rb
@@ -111,3 +111,18 @@ class ImageStringIO < StringIO
     super(string, mode)
   end
 end
+
+# reimplementing discordrb's ignore_bot with a whitelist
+module CommandEventIntercept
+  def call(event, arguments, _chained = false, _check_permissions = true)
+    return if event.author.bot_account && !(QBot.config.bot_id_allowlist.include? event.author.id)
+
+    super(event, arguments, _chained, _check_permissions)
+  end
+end
+
+module Discordrb::Commands
+  class Command
+    prepend CommandEventIntercept
+  end
+end


### PR DESCRIPTION
Merges after https://github.com/arch-community/qbot/pull/225

This one's super silly. Important changes are at bottom of modules/init.rb. Tested and works as intended.

I really like ruby's monkeypatching mechanics though! Far better than Python's, ha.