### PR TITLE
fix: match note name without quotes

### DIFF
--- a/modules/notes.rb
+++ b/modules/notes.rb
@@ -11,7 +11,7 @@ module Notes
     #     name text
     #     "name with spaces" text
     #     'name with spaces' text
-    re = /^(?<quote>['"]?)(?<name>(?:(?!\k<quote>).)+?)\k<quote>\s(?<text>.+)$/
+    re = /^(?<quote>['"]?)(?<name>.+?)\k<quote>\s(?<text>.+)$/
 
     case re.match(text)
     in { name:, text: }


### PR DESCRIPTION
![image](https://github.com/arch-community/qbot/assets/30599715/1d2f8415-7993-4f7e-b162-3e29c0837e14)
![image](https://github.com/arch-community/qbot/assets/30599715/e36136e7-ceee-4fe1-86e6-f536531dc4a8)
![image](https://github.com/arch-community/qbot/assets/30599715/fd11ede1-a775-4a75-84e6-8eb10c1f7e6f)
