### PR TITLE
feat: New support module, the solve, drop and reopen commands for the forum support channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Modules:
 - `help` provides a help command that displays information about commands.
 - `queries` helps manage support channels using a database of support questions.
 - `snippets` lets users invoke configurable text snippets.
+- `support` adds support channel related commands (forum posts).
 - `util` provides simple utility commands.
 - `xkcd` allows searching and posting XKCD comics.
 

--- a/config/global.yml.example
+++ b/config/global.yml.example
@@ -41,6 +41,7 @@ modules:
   - quotes
   - sitelenpona
   - snippets
+  - support
   - tio
   - tokipona
   - util

--- a/modules/support.rb
+++ b/modules/support.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+##
+# mrbartix
+# changes the title of the support post (well, any thread)
+# TODO: add tag support to this, when discordrb implements support for them
+module Support
+  extend Discordrb::Commands::CommandContainer
+  
+  # add the command
+  command :solve, {
+    aliases: %i[slv .],
+    help_available: true,
+    usage: ':solve',
+    min_args: 0
+  } do |event, *_|
+    # check if the channel is a thread and if its closed
+    next embed("That's not a thread!") unless event.channel.thread?
+    next embed("This channel is already closed!") if event.channel.name.start_with?("[SOLVED]", "[DROPPED]")
+    
+    # change the title
+    event.channel.name = "[SOLVED] #{event.channel.name}"
+    embed("Success!")
+  end
+  command :drop, {
+    aliases: %i[drp .],
+    help_available: true,
+    usage: ':drop',
+    min_args: 0
+  } do |event, *_|
+    # check if the channel is a thread and if its closed
+    next embed("That's not a thread!") unless event.channel.thread?
+    next embed("This channel is already closed!") if event.channel.name.start_with?("[SOLVED]", "[DROPPED]")
+    # change the title
+    event.channel.name = "[DROPPED] #{event.channel.name}"
+    embed("Success!")
+  end
+    command :reopen, {
+    help_available: true,
+    usage: ':reopen',
+    min_args: 0
+  } do |event, *_|
+    # check if the channel is a thread and if its closed
+    next embed("That's not a thread!") unless event.channel.thread?
+    next embed("This channel is already closed!") unless event.channel.name.start_with?("[SOLVED]", "[DROPPED]")
+    # change the title
+    # removes solved or dropped from the name
+    if event.channel.name.start_with?("[SOLVED]")
+      event.channel.name = event.channel.name.sub("[SOLVED]", "")
+    elsif event.channel.name.start_with?("[DROPPED]")
+      event.channel.name = event.channel.name.sub("[DROPPED]", "")
+    end
+    embed("Success!")
+  end
+end

--- a/share/global_config.schema.json
+++ b/share/global_config.schema.json
@@ -114,6 +114,7 @@
 					"queries",
 					"sitelenpona",
 					"snippets",
+					"support",
 					"tio",
 					"tokipona",
 					"util",


### PR DESCRIPTION
added a module [support] that adds three commands:
.solve (alias: .slv) that puts [SOLVED] in the beginning of the post's title
.drop (alias: .drp) does the same as .solve, but puts [DROPPED]
.reopen (no alias) reopens the post, removing [SOLVED] or [DROPPED] from the title